### PR TITLE
update aiopg to the latest release Fix #2

### DIFF
--- a/aiohttp_baseapi/project_template/src/.meta/packages
+++ b/aiohttp_baseapi/project_template/src/.meta/packages
@@ -2,7 +2,7 @@
 --extra-index-url http://pypi.wargaming.net/root/prod/
 
 aiohttp==2.3.8
-aiopg==0.13.1
+aiopg==0.16.0
 alembic==0.9.2
 SQLAlchemy==1.1.10
 python-json-logger==0.1.5

--- a/aiohttp_baseapi/project_template/src/.meta/packages
+++ b/aiohttp_baseapi/project_template/src/.meta/packages
@@ -1,6 +1,3 @@
---trusted-host pypi.wargaming.net
---extra-index-url http://pypi.wargaming.net/root/prod/
-
 aiohttp==2.3.8
 aiopg==0.16.0
 alembic==0.9.2


### PR DESCRIPTION
Fix version of aiopg package.

According to PEP 492, async and await are now keywords and cannot be used as names. This has been fixed in later versions of aiopg. This fix update aiopg to the latest version.

Fix #2